### PR TITLE
Insert into schema migrations table after doing a schema load;

### DIFF
--- a/lib/blueshift.rb
+++ b/lib/blueshift.rb
@@ -3,6 +3,7 @@ require 'blueshift/version'
 require 'blueshift/migration'
 require 'sequel'
 require 'sequel/adapters/redshift'
+require 'sequel/extensions/schema_dumper_ext'
 
 module Blueshift
   def self.migration(&block)

--- a/lib/blueshift/migration.rb
+++ b/lib/blueshift/migration.rb
@@ -9,6 +9,8 @@ module Blueshift
   class Migration
     attr_reader :postgres_migration, :redshift_migration, :use_transactions
     MIGRATION_DIR = File.join(Dir.pwd, 'db/migrations')
+    SCHEMA_COLUMN = :filename
+    SCHEMA_TABLE  = :schema_migrations
 
     def initialize(&block)
       @postgres_migration = Sequel::SimpleMigration.new
@@ -44,13 +46,21 @@ module Blueshift
       end
     end
 
+    def self.insert_into_schema_migrations(db)
+      migration_files = Dir["#{MIGRATION_DIR}/*"]
+      migration_files.each do |path|
+        f = File.basename(path)
+        db.from(SCHEMA_TABLE).insert(SCHEMA_COLUMN=>f)
+      end
+    end
+
     class << self
       def run_pg!
-        Sequel::Migrator.run(POSTGRES_DB, MIGRATION_DIR, column: :postgres_version)
+        Sequel::Migrator.run(POSTGRES_DB, MIGRATION_DIR)
       end
 
       def run_redshift!
-        Sequel::Migrator.run(REDSHIFT_DB, MIGRATION_DIR, column: :redshift_version)
+        Sequel::Migrator.run(REDSHIFT_DB, MIGRATION_DIR)
       end
 
       def run_both!

--- a/lib/blueshift/version.rb
+++ b/lib/blueshift/version.rb
@@ -1,3 +1,3 @@
 module Blueshift
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/lib/sequel/extensions/redshift_schema_dumper.rb
+++ b/lib/sequel/extensions/redshift_schema_dumper.rb
@@ -9,7 +9,7 @@ module Sequel
         gen = dump_table_generator(table, options)
         commands = [gen.dump_columns, gen.dump_constraints, gen.dump_indexes].reject { |x| x == '' }.join("\n\n")
 
-        "create_table(#{table.inspect}#{table_options(table, gen, options)}) do\n#{commands.gsub(/^/o, '  ')}\nend"
+        "create_table!(#{table.inspect}#{table_options(table, gen, options)}) do\n#{commands.gsub(/^/o, '  ')}\nend"
       end
 
       def table_options(table, gen, options)

--- a/lib/sequel/extensions/schema_dumper_ext.rb
+++ b/lib/sequel/extensions/schema_dumper_ext.rb
@@ -1,0 +1,10 @@
+require 'sequel/extensions/schema_dumper'
+module Sequel
+  module SchemaDumper
+    alias_method :dump_table_schema_without_force, :dump_table_schema
+
+    def dump_table_schema(table, opts=OPTS)
+      dump_table_schema_without_force(table, opts).gsub('create_table(', 'create_table!(')
+    end
+  end
+end

--- a/spec/sequel/adapters/postgres_ext_spec.rb
+++ b/spec/sequel/adapters/postgres_ext_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+PGDB.extension :schema_dumper
+
 RSpec.describe Sequel::Postgres do
   describe '#create_table' do
     describe 'column types' do
@@ -14,5 +16,23 @@ RSpec.describe Sequel::Postgres do
         end
       end
     end
+  end
+
+  describe 'schema dumper' do
+    subject { PGDB.dump_table_schema(:apples) }
+
+    let(:create_macro) do
+      ['create_table!(:apples) do',
+       '  String :crunchiness, :text=>true',
+       'end'].join("\n")
+    end
+
+    before do
+      PGDB.create_table!(:apples, sortkeys: [:crunchiness]) do
+        String :crunchiness
+      end
+    end
+
+    it { is_expected.to eq create_macro }
   end
 end

--- a/spec/sequel/extensions/redshift_schema_dumper_spec.rb
+++ b/spec/sequel/extensions/redshift_schema_dumper_spec.rb
@@ -24,7 +24,7 @@ describe Sequel::Redshift::SchemaDumper do
     subject { DB.dump_table_schema(:apples) }
 
     context 'with distkey and sortkeys' do
-      let(:create_table) { 'create_table(:apples, :distkey=>:region, :sortkeys=>[:colour, :crunchiness]) do' }
+      let(:create_table) { 'create_table!(:apples, :distkey=>:region, :sortkeys=>[:colour, :crunchiness]) do' }
       it 'should output the distkey and sortkeys' do
         is_expected.to eq create_macro
       end
@@ -32,13 +32,13 @@ describe Sequel::Redshift::SchemaDumper do
 
     context 'no diskey or sortkeys' do
       let(:options) { {} }
-      let(:create_table) { 'create_table(:apples) do' }
+      let(:create_table) { 'create_table!(:apples) do' }
       it { is_expected.to eq create_macro }
     end
 
     context 'with sortstyle' do
       let(:options) { {distkey: :region, sortkeys: [:colour, :region, :crunchiness], sortstyle: :interleaved} }
-      let(:create_table) { 'create_table(:apples, :distkey=>:region, :sortkeys=>[:colour, :region, :crunchiness], :sortstyle=>:interleaved) do' }
+      let(:create_table) { 'create_table!(:apples, :distkey=>:region, :sortkeys=>[:colour, :region, :crunchiness], :sortstyle=>:interleaved) do' }
       it { is_expected.to eq create_macro }
     end
   end


### PR DESCRIPTION
Force creation of tables when doing a *:schema:load;
regenerates schema dump file after a migration completes.