### PR TITLE
Update how Dataset gets set for the Sequel gem

### DIFF
--- a/lib/sequel/adapters/redshift.rb
+++ b/lib/sequel/adapters/redshift.rb
@@ -41,6 +41,10 @@ module Sequel
 
       private
 
+      def dataset_class_default
+        Dataset
+      end
+
       def type_literal_generic_string(column)
         super(column.merge(text: false))
       end
@@ -128,8 +132,6 @@ module Sequel
     end
 
     class Dataset < Postgres::Dataset
-      Database::DatasetClass = self
-
       # Redshift doesn't support RETURNING statement
       def insert_returning_sql(sql)
         # do nothing here


### PR DESCRIPTION
I'm unsure if this gem is being actively maintained or not, but our organization is testing it out to help handle migrations for a new Redshift project we're working on so we don't have to handle it internally. We ran into this and figured we ought PR it in case anyone else is having issues!

[Apparently how the Dataset is injected/set changed.](https://github.com/jeremyevans/sequel/blob/a5a4d8020438b594ec9c1f61211ee292468998ba/doc/release_notes/4.46.0.txt#L222) This PR appears to correct the issue no problem, though I don't know that I'm familiar enough with the inner workings of the spec suite / Sequel gem to write an appropriate spec for this.

cc @adomokos 